### PR TITLE
Fix max_nonce for --benchmark

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1190,7 +1190,7 @@ static void *miner_thread(void *userdata)
 			switch (opt_algo) {
 			case ALGO_YESCRYPT:
 			case ALGO_YESPOWER:
-				max64 = 0x3fffff;
+				max64 = 0xfff;
 				break;
 			}
 		}


### PR DESCRIPTION
Since the initial value of `max_nonce` is too large, it takes a very long time to display `--benchmark` result.